### PR TITLE
Add support for multiple exif subdirs and make FileExists function timezone independent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ bld/
 
 # Visual Studio 2015/2017 cache/options directory
 .vs/
+.vscode/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 

--- a/Ingesting/IngestTask.cs
+++ b/Ingesting/IngestTask.cs
@@ -178,18 +178,21 @@ namespace DcimIngester.Ingesting
                 metadata = MetadataExtractor.ImageMetadataReader.ReadMetadata(path);
             }
             catch (MetadataExtractor.ImageProcessingException) { return null; }
-
-            ExifSubIfdDirectory? exif = metadata.OfType<ExifSubIfdDirectory>().SingleOrDefault();
-            string? dto = exif?.GetDescription(ExifDirectoryBase.TagDateTimeOriginal);
-
-            if (dto == null)
-                return null;
-
-            try
+                                  
+            // Search all exif subdirs for date taken
+            foreach (ExifSubIfdDirectory exif in metadata.OfType<ExifSubIfdDirectory>()) 
             {
-                return DateTime.ParseExact(dto, "yyyy:MM:dd HH:mm:ss", null);
-            }
-            catch (FormatException) { return null; }
+                string? dto = exif?.GetDescription(ExifDirectoryBase.TagDateTimeOriginal);
+                if (dto != null) 
+                {
+                    try 
+                    {
+                        return DateTime.ParseExact(dto, "yyyy:MM:dd HH:mm:ss", null);
+                    }
+                    catch (FormatException) { return null; }
+                }
+            };
+            return null;
         }
 
         /// <summary>

--- a/Utilities.cs
+++ b/Utilities.cs
@@ -45,7 +45,7 @@ namespace DcimIngester
         {
             // GetCreationTime() returns the below time if the file does not exist and throws an
             // exception if there was an error
-            return File.GetCreationTime(path) != new DateTime(1601, 1, 1, 0, 0, 0);
+            return File.GetCreationTimeUtc(path) != new DateTime(1601, 1, 1, 0, 0, 0);
         }
 
         /// <summary>


### PR DESCRIPTION
This PR fixes an issues in the FileExists function where it would always return true if the timezone was set to anything other than UTC and adds support for image types that have multiple Exif SubIFD entries (in my case DNG file from the DJI mini 2)